### PR TITLE
ldapi:// + SASL authentication fix.

### DIFF
--- a/lib/Net/LDAP.pm
+++ b/lib/Net/LDAP.pm
@@ -384,7 +384,10 @@ sub bind {
       # If we're talking to a round-robin, the canonical name of
       # the host we are talking to might not match the name we
       # requested
-      my $connected_name = $ldap->{net_ldap_socket}->peerhost;
+      my $connected_name;
+      if ($ldap->{net_ldap_socket}->can('peerhost')) {
+        $connected_name = $ldap->{net_ldap_socket}->peerhost;
+      }
       $connected_name ||= $ldap->{net_ldap_host};
 
       $sasl_conn = eval {


### PR DESCRIPTION
When performing SASL authentication, the Net::LDAP calls the ->peerhost() method on the LDAP connection's IO::Socket object. For UNIX domain sockets, no peerhost() method is defined. This patch checks whether the peerhost() method is defined before calling it.
