### PR TITLE
RT#77180 use "sslv23" instead of "sslv2/3" for sslversion

### DIFF
--- a/lib/Net/LDAP.pm
+++ b/lib/Net/LDAP.pm
@@ -225,6 +225,11 @@ sub _SSL_context_init_args {
       $passwdcb = $arg->{'keydecrypt'};
   }
 
+  # allow deprecated "sslv2/3" in addition to IO::Socket::SSL's "sslv23"
+  if (defined $arg->{'sslversion'}) {
+      $arg->{'sslversion'} =~ s:sslv2/3:sslv23:io;
+  }
+
   (
     SSL_cipher_list     => defined $arg->{'ciphers'} ? $arg->{'ciphers'} : 'ALL',
     SSL_ca_file         => exists  $arg->{'cafile'}  ? $arg->{'cafile'}  : '',
@@ -236,7 +241,7 @@ sub _SSL_context_init_args {
     SSL_cert_file       => $clientcert,
     SSL_verify_mode     => $verify,
     SSL_version         => defined $arg->{'sslversion'} ? $arg->{'sslversion'} :
-                           'sslv2/3',
+                           'sslv23',
     %verifycn_ctx,
   );
 }

--- a/lib/Net/LDAP.pod
+++ b/lib/Net/LDAP.pod
@@ -180,7 +180,7 @@ B<Example>
 
 LDAPS connections have some extra valid options, see the
 L<start_tls|/start_tls> method for details. Note the default value for
-'sslversion' for LDAPS is 'sslv2/3', and the default port for LDAPS
+'sslversion' for LDAPS is 'sslv23', and the default port for LDAPS
 is 636.
 
 For LDAPI connections, HOST is actually the location of a UNIX domain
@@ -755,7 +755,7 @@ The server must provide a certificate, and it must be valid.
 If you set verify to optional or require, you must also set either
 cafile or capath. The most secure option is B<require>.
 
-=item sslversion =E<gt> 'sslv2' | 'sslv3' | 'sslv2/3' | 'tlsv1'
+=item sslversion =E<gt> 'sslv2' | 'sslv3' | 'sslv23' | 'tlsv1'
 
 This defines the version of the SSL/TLS protocol to use. Defaults to
 B<'tlsv1'>.


### PR DESCRIPTION
IO::Socket::SSL's maintainer wants to migrate away from the value "sslv2/3"
for IO::Socket::SSL parameter SSL_version, which is where sslversion ends.

Adapt documentation and code to the value "sslv23", which is accepted in
IO::Socket::SSL since version 0.90 released in 2002.

For compatibility purposes still acept "sslv2/3", but convert it to "sslv23".
