### PR TITLE
Handle intermediate messages like entries when callback is provided.

### DIFF
--- a/lib/Net/LDAP/Message.pm
+++ b/lib/Net/LDAP/Message.pm
@@ -148,10 +148,11 @@ sub decode { # $self, $pdu, $control
 
     my $intermediate = Net::LDAP::Intermediate->from_asn($data);
 
-    push(@{$self->{'intermediate'} ||= []}, $intermediate);
-
-    $self->{callback}->($self, $intermediate)
-      if (defined $self->{callback});
+    if (defined $self->{callback}) {
+      $self->{callback}->($self, $intermediate)
+    } else {
+      push(@{$self->{'intermediate'} ||= []}, $intermediate);
+    }
 
     return $self;
   } else {


### PR DESCRIPTION
When a callback is provided, intermediate messages are still accumulated in the $self->{intermediate} array for later inspection. This is not desirable in some cases (e.g., a large LDAP Sync presentation). This fix simply passes the message to the callback (as is done with non-intermediate messages) when a callback is provided.
