### PR TITLE
Present the name provided by the caller for GSSAPI/SASL authentication

### DIFF
--- a/lib/Net/LDAP.pm
+++ b/lib/Net/LDAP.pm
@@ -424,14 +424,22 @@ sub bind {
       # If we're talking to a round-robin, the canonical name of
       # the host we are talking to might not match the name we
       # requested
-      # In that case passing sasl_authenticate_with => 'ip' into
-      # bind allows us to pass the IP address of our peer to sasl
-      # so that it can perform a reverse dns lookup to determine
+      # In that case passing sasl_authenticate_with => 'connected_ip'
+      # into bind allows us to pass the IP address of our peer to
+      # sasl so that it can perform a reverse dns lookup to determine
       # the name against we wish to authenticate.
+      # It's also true that some kerberos installations disable
+      # reverse dns lookups (e.g. mit rdns=no).
+      # In that case passing sasl_authenticate_with => 'connected_name'
+      # into bind will cause us to perform our own DNS resolution of the
+      # IP address of our peer, and pass that to sasl.
       my $service_name = $ldap->{net_ldap_host};
       if (exists $arg->{sasl_authenticate_with}) {
-          if (lc($arg->{sasl_authenticate_with}) eq 'ip') {
-            $service_name = $ldap->{net_ldap_socket}->peerhost;
+          if (lc($arg->{sasl_authenticate_with}) eq 'connected_ip') {
+              $service_name = $ldap->{net_ldap_socket}->peerhost;
+          } elsif (lc($arg->{sasl_authenticate_with}) eq 'connected_name') {
+              my $iaddr = inet_aton($ldap->{net_ldap_socket}->peerhost);
+              $service_name = gethostbyaddr($iaddr, AF_INET);
           }
       }
 

--- a/lib/Net/LDAP.pod
+++ b/lib/Net/LDAP.pod
@@ -318,11 +318,16 @@ overridden with the C<sasl_authenticate_with> option.
 
 =item sasl_authenticate_with =E<gt> TYPE
 
-When binding with a SASL mechanism, if set to the string C<IP>, the
-hostname passed by C<Net::LDAP> to C<client_new> will be the result
-of calling C<peerhost> on the socket.
+When binding with a SASL mechanism, if set to the string
+C<CONNECTED_IP>, the hostname passed by C<Net::LDAP> to C<client_new>
+will be the result of calling C<peerhost> on the socket.
 
-If neither this nor the default is not correct for your environment,
+When binding with a SASL mechanism, if set to the string
+C<CONNECTED_NAME>, the hostname passed by C<Net::LDAP> to C<client_new>
+will be the result of performing a reverse dns lookup on the
+C<peerhost> on the socket.
+
+If neither of these nor the default is correct for your environment,
 consider calling C<client_new> and passing the client connection
 object.
 


### PR DESCRIPTION
In commit af63067 on 2008-04-21 there was an attempt to "Fix a problem with Net::LDAP when talking to a round-robin LDAP server(s) using SASL/GSSAPI authentication to use the provided hostname not the canonical name"

This commit changed Net::LDAP so that it passes an IP Address to SASL/GSSAPI as the server identification instead of the server name supplied by the client. This assumes that Kerberos (the usual GSSAPI mechanism employed) will do a reverse DNS lookup to construct the Kerberos service principal name, since IP Addresses are almost never used for this. This need not be the case; MIT Kerberos, for example, can be configured to resolve CNAME and PTR records, just CNAMEs, or perform no DNS canonicalization at all.

Since we've configured Kerberos to not do PTR lookups, Net::LDAP with SASL/GSSAPI does not work in our environment.

The problem here is in assuming that it's even possible for Net::LDAP to (as the Changes explanation says) "Pass correct hostname to SASL when connecting to a round-robin" There's no real way for the library to know what the "correct hostname" is supposed to be, beyond that specified by the caller. It's the responsibility of the systems administrator to ensure that Kerberos, DNS records, service principals, and application configuration are arranged such that they all work together, and if a library tries to second-guess this by altering the name passed to it, it will likely cause this kind of breakage at some point. As a default, a library should pass the hostname unaltered to SASL/GSSAPI so that it can obey the local rules for locating the correct service principal.

This isn't only a functional problem, it could be considered a security problem. DNS is insecure, but mutual authentication with Kerberos ensures that we can trust the server to which we connect and successfully authenticate. If we use the same (possibly compromised / spoofed) DNS system to find our server and construct the service name we use for authentication, we lose that benefit from mutual authentication. If the LDAP server is used to provide passwd/group maps for unix hosts, the results could be catastrophic.

On the other hand, sometimes we face the opposite problem -- getting Kerberos to work in a misconfigured environment where the rules in effect produce the wrong result. In that case it may be useful to offer the library client the option of performing some DNS canonicalization on its own, or alternately allow the client to specify the Kerberos principal directly -- but these should be options, not the default.

This patch reverts the behavior to using the name supplied by the caller instead of using the address to which a connection has been established. This will reliably produce the service name that the caller intended to authenticate. It also provides a new (documented) OPTION to bind,  "sasl_authenticate_with" which if set to the (case insensitive) string "CONNECTED_IP", enables the current behavior, and if set to the (case insensitive string) "CONNECTED_NAME", performs the reverse dns lookup on the peeraddr (for environments which have kerberos configured to not perform reverse lookups).

I understand that changing the default behavior like this is not 100% backwards compatible and that there are some users whose programs may break as a result, but in my opinion the security ramifications of this behavior warrant some consideration.
