### PR TITLE
Handle SASL security layers correctly on rebind.

### DIFF
--- a/lib/Net/LDAP/Bind.pm
+++ b/lib/Net/LDAP/Bind.pm
@@ -35,10 +35,13 @@ sub decode {
 	  or $self->set_error(LDAP_DECODING_ERROR, 'LDAP decode error'), return;
   }
 
-  if ($sasl and $bind->{resultCode} == LDAP_SUCCESS) {
-    $sasl->property('ssf', 0)  if !$sasl->property('ssf');
-    $ldap->{net_ldap_socket} = $sasl->securesocket($ldap->{net_ldap_socket});
-  }
+  # Put the new layer over the raw socket, to get rid of any old layer,
+  # but only if we will be using a new layer. If we rebind but don't
+  # negotiate a new security layer, the old layer remains in place.
+  $sasl and $bind->{resultCode} == LDAP_SUCCESS
+    and $sasl->property('ssf')
+    and $ldap->{net_ldap_socket} = 
+        $sasl->securesocket($ldap->{net_ldap_rawsocket});
 
   return $self->SUPER::decode($result)
     unless $bind->{resultCode} == LDAP_SASL_BIND_IN_PROGRESS;


### PR DESCRIPTION
According to the RFC, if we are using a SASL security layer, then we
rebind and negotiate a new security layer, the new layer replaces the
old. If, on the other hand, the rebind doesn't negotiate a security
layer, then the old layer remains in place. Previously Net::LDAP was
attempting to apply the new layer (if any) on top of the old layer,
which is incorrect.

Rebind was also failing if a security layer had previously been
negotiated since the security-layer filehandle doesn't support socket
operations. Since we now need to keep the raw (TCP or SSL) filehandle
around anyway, we can do the socket operations on that instead.
