### PR TITLE
delete(): return $self if called w/o args

### DIFF
--- a/lib/Net/LDAP/Entry.pm
+++ b/lib/Net/LDAP/Entry.pm
@@ -214,7 +214,7 @@ sub delete {
 
   unless (@_) {
     $self->changetype('delete');
-    return;
+    return $self;
   }
 
   my $cmd = $self->{changetype} eq 'modify' ? [] : undef;


### PR DESCRIPTION
else the example in the docs of $entry->delete->update($ldap) does
not work
