### PR TITLE
Remove Test Requirement to Text::Soundex

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,6 @@ test_requires	'File::Basename';
 test_requires	'File::Compare';
 test_requires	'File::Path';
 test_requires	'IO::File';
-test_requires	'Text::Soundex';
 
 features
         'IPv6 support' => [


### PR DESCRIPTION
The test requirement to Text::Soundex causes the need to install a module that needs a compiler to be built. As the general project guidelines seem to target a mostly perl only based install, this should be considered for removal. As far as I can see, Text::Soundex is only an option to the Net::LDAP::FilterMatch, so there is no need to require it here.