### PR TITLE
Support for reading LDIF files with comments

### DIFF
--- a/data/00-comments.ldif
+++ b/data/00-comments.ldif
@@ -1,0 +1,44 @@
+# add 1470034845 dc=acme,dc=com cn=foo,ou=admins,dc=acme,dc=com  conn=-1
+dn: uid=coyote004,ou=roadrunners,dc=acme,dc=com
+changetype: add
+uid: 004
+mail: coyote@acme.com
+cn: Coyote
+sn: De la mancha
+givenName: Coyote
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: eduPerson
+objectClass: sambaSamAccount
+structuralObjectClass: eduPerson
+creatorsName: cn=foo,ou=admins,dc=acme,dc=com
+createTimestamp: 20160801070045Z
+entryCSN: 20160801070445.104180Z#000000#001#000000
+modifiersName: cn=foo,ou=admins,dc=acme,dc=com
+modifyTimestamp: 20160801070045Z
+# end add 1470034845
+
+# add 1470034847 dc=acme,dc=com cn=foo,ou=admins,dc=acme,dc=com  conn=-1
+dn: uid=coyote006, ou=roadrunners,dc=acme,dc=com
+changetype: add
+uid: 004
+mail: coyote@acme.com
+cn: Coyote
+sn: De la mancha
+givenName: Coyote
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+objectClass: eduPerson
+objectClass: sambaSamAccount
+structuralObjectClass: eduPerson
+creatorsName: cn=foo,ou=admins,dc=acme,dc=com
+createTimestamp: 20160801070045Z
+entryCSN: 20160801070445.104180Z#000000#001#000000
+modifiersName: cn=foo,ou=admins,dc=acme,dc=com
+modifyTimestamp: 20160801070045Z
+# end add 1470034847
+

--- a/lib/Net/LDAP/Entry.pm
+++ b/lib/Net/LDAP/Entry.pm
@@ -29,6 +29,15 @@ sub new {
   return $entry;
 }
 
+# API addition to support LDIF comments
+sub comments {
+  # Set or get comments read by Net::LDAP::LDIF as an arrayref.
+  my $self = shift;
+  return $self->{comments} unless @_;
+  $self->{comments} = shift;
+  return $self;
+}
+
 sub clone {
   my $self  = shift;
   my $clone = $self->new();

--- a/lib/Net/LDAP/Entry.pod
+++ b/lib/Net/LDAP/Entry.pod
@@ -189,6 +189,16 @@ specified by setting the entry attributes newrdn, deleteoldrdn, and
 
 =back
 
+=item comments ( )
+
+The comments methods will return an array reference with (string) comments 
+read by L<Net::LDAP::LDIF>.
+
+=item comments ( ARRAYREF )
+
+The comments method setter accepts an array reference with (string)
+comments. Specifically, this method is called by L<Net::LDAP::LDIF>.
+
 =item delete ( )
 
 Delete the entry from the server on the next call to C<update>.

--- a/lib/Net/LDAP/LDIF.pod
+++ b/lib/Net/LDAP/LDIF.pod
@@ -151,6 +151,11 @@ If this option is not given, attribute values are treated as byte strings.
 
 Example: raw =E<gt> qr/(?i:^jpegPhoto|;binary)/
 
+=item comments =E<gt> 1
+
+Read comments in the LDIF and add them to the corresponding L<Net::LDAP::Entry>.
+The comments can be retrieved with its C<comments()> method.
+
 =back
 
 =back

--- a/t/00ldif-entry.t
+++ b/t/00ldif-entry.t
@@ -4,16 +4,17 @@ BEGIN {
   require "t/common.pl";
 }
 
-use Test::More tests => 16;
+use Test::More tests => 17;
 use File::Compare qw(compare_text);
 
 use Net::LDAP::LDIF;
 
-my $infile   = "data/00-in.ldif";
-my $outfile1 = "$TEMPDIR/00-out1.ldif";
-my $outfile2 = "$TEMPDIR/00-out2.ldif";
-my $cmpfile1 = "data/00-cmp.ldif";
-my $cmpfile2 = $infile;
+my $infile        = "data/00-in.ldif";
+my $outfile1      = "$TEMPDIR/00-out1.ldif";
+my $outfile2      = "$TEMPDIR/00-out2.ldif";
+my $cmpfile1      = "data/00-cmp.ldif";
+my $cmpfile2      = $infile;
+my $comments_file = "data/00-comments.ldif";
 
 my $ldif = Net::LDAP::LDIF->new($infile,"r");
 
@@ -182,4 +183,9 @@ ok(($r and  join("*", sort keys %$r) eq "*;en-us"), "name keys");
 ok(($r and $r->{''} and @{$r->{''}} == 1 and $r->{''}[0] eq 'Graham Barr'), "name alloptions");
 
 ok(($r and $r->{';en-us'} and @{$r->{';en-us'}} == 1 and $r->{';en-us'}[0] eq 'Bob'), "name alloptions Bob");
+
+# Test comments
+my $ldif_comments = Net::LDAP::LDIF->new($comments_file,"r");
+my $e_comments    = $ldif_comments->read_entry;
+ok( (grep /^#/, @{ $e_comments->comments()}), "Comments found" );
 


### PR DESCRIPTION
Hi,

Comments are valid elements of an LDIF file. This PR add support for retrieving the comments of an LDAP entry and it's enabled by an option (comments => 1) in Net::LDAP::LDIF->new.

I will describe my use case as an illustration of the use of this functionality: 
A daemon reads the audit log of an OpenLDAP server (a valid LDIF file) and an external action is triggered (ldap modification, mail, etc) by the change of certain attributes. In order to keep the state between runs (e.g. restart), I use the OpenLDAP transition numbers as written by the OpenLDAP in the audtilog:

```ldif
# modify 1470032840 dc=acme,dc=com cn=foo,ou=admins,dc=acme,dc=com  conn=-1
dn: uid=coyote001,ou=roadrunners,dc=acme,dc=com
changetype: modify
delete: mail
-
replace: entryCSN
entryCSN: 20160801062719.107755Z#000000#001#000000
-
replace: modifiersName
modifiersName: cn=foo,ou=admins,dc=acme,dc=com
-
replace: modifyTimestamp
modifyTimestamp: 20160801062719Z
-
# end modify 1470032840
```

I tried to stay as close as possible to your coding style and I also put the added code and documentation next to similar entries. The added test verifies that the new functionality does not cause breakage.

In case you decide that this PR is useful to be eventually merged, feel free to ask for adaptations or extra tests.

Regards and thank you for your work