### PR TITLE
Add '.' to @INC in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 # -*- perl -*-
 
+use lib '.';
 use inc::Module::Install;
 
 perl_version    5.008001;


### PR DESCRIPTION
Perl 5.25.11 and newer (including the stable version 5.26.0 when
it is released), no longer has the current directory '.' in the
@INC path.  This simple fix will keep the module working when
the new stable version is released.