### PR TITLE
Net:LDAP:Entry->delete() : does not push to changes when nothing to delete

### DIFF
--- a/lib/Net/LDAP/Entry.pm
+++ b/lib/Net/LDAP/Entry.pm
@@ -239,12 +239,14 @@ sub delete {
 	if $cmd;
     }
     else {
-      delete $attrs->{$lc_type};
+      if (exists $attrs->{$lc_type} ) {
+        delete $attrs->{$lc_type};
 
-      @{$self->{asn}{attributes}}
-	= grep { $lc_type ne lc($_->{type}) } @{$self->{asn}{attributes}};
+        @{$self->{asn}{attributes}}
+        = grep { $lc_type ne lc($_->{type}) } @{$self->{asn}{attributes}};
 
-      push @$cmd, $type, []  if $cmd;
+        push @$cmd, $type, []  if $cmd;
+      }
     }
   }
 


### PR DESCRIPTION

No more push to local changes when delete entire attribute that does not
exists in the entry.