### PR TITLE
Added search scope constants to Constant.pm

### DIFF
--- a/lib/Net/LDAP/Constant.pm
+++ b/lib/Net/LDAP/Constant.pm
@@ -430,6 +430,18 @@ Refresh Required.
 
 =back
 
+=head2 Search Scopes
+
+=over 4
+
+=item LDAP_SEARCH_SCOPE_BASE_OBJECT (0)
+
+=item LDAP_SEARCH_SCOPE_ONE_LEVEL (1)
+
+=item LDAP_SEARCH_SCOPE_SUBTREE (2)
+
+=back
+
 =head2 Control OIDs
 
 =over 4


### PR DESCRIPTION
Hi Peter,

I am coming back to Perl after a good while, and I had a couple of tickets in RT for my module Net::LDAP::SimpleServer. One of them added scope based search to it (which is kind of an obvious thing in an LDAP server, but as I was playing around with this back in the day, I wasn't too concerned about completeness, it was more a proof of concept than anything else). Hence, I am creating a Constant.pm module in my project to hold these search scope constants, but as I come to think about it, I believe it would make more sense for them to be in Net::LDAP itself. I mean, anyone using LDAP might be interested in using that, not just my ugly little server.

Hope you find that helpful.

Cheers,
Alexei