### PR TITLE
add -r option for reverse hierarchical sort on changetype: delete ent…

### DIFF
--- a/contrib/ldifsort.pl
+++ b/contrib/ldifsort.pl
@@ -120,7 +120,7 @@ sub cmpdn {
 		$cadn =~ s/^.*,(?=.)//; $cbdn =~ s/^.*,(?=.)//;
 	}
 	# reverse sort order if hierarchical sorting and delete entries for modify ldifs
-	if ($args{h} && $args{r} && $a->[2] == "delete" && $b->[2] == "delete") {
+	if ($args{h} && $args{r} && $a->[2] eq "delete" && $b->[2] eq "delete") {
 	    $cbdn cmp $cadn;
 	} else {
         $cadn cmp $cbdn;


### PR DESCRIPTION
…ries

When exporting the current server state as an ldif and having the new state as ldif, ldifdiff prints out a possibly non-hierarchical sorted ldif file which is not usable by ldapmodify. ldifsort sorts all the dns with the -h option correctly, but in the case of delete entries the modification ldif has to be sorted inversely for correctly reflecting the changes.