### PR TITLE
Correct a shell bang in data/regenerate_cert.sh

### DIFF
--- a/data/regenerate_cert.sh
+++ b/data/regenerate_cert.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 # regenerate server certificate for the SSL tests
 
 if [ -e openssl.cnf ]; then


### PR DESCRIPTION
The script was missing an exclamation mark on the first line.