### PR TITLE
Issue with restricting connections to IPv4 or IPv6 only

### DIFF
--- a/lib/Net/LDAP.pm
+++ b/lib/Net/LDAP.pm
@@ -166,7 +166,7 @@ sub connect_ldap {
     PeerPort   => $port,
     LocalAddr  => $arg->{localaddr} || undef,
     Proto      => 'tcp',
-    Domain     => $domain,
+    ($class eq 'IO::Socket::IP' ? 'Family' : 'Domain')     => $domain,
     MultiHomed => $arg->{multihomed},
     Timeout    => defined $arg->{timeout}
 		 ? $arg->{timeout}


### PR DESCRIPTION
The parameter to use to explicitly restrict connections to IPv6 or IPv4 is called `Domain` in `IO::Socket::Net` and `Family` for `IO::Socket::IP`. This pull request adds logic to dynamically generate the parameter name depending on the underlying module being used.

Logic used is to set it to `Family` if using `IO::Socket::IP` and `Domain` using any other module.