### PR TITLE
Do not default IO::Socket::IP to AI_ADDRCONFIG flag

### DIFF
--- a/lib/Net/LDAP.pm
+++ b/lib/Net/LDAP.pm
@@ -167,6 +167,9 @@ sub connect_ldap {
     LocalAddr  => $arg->{localaddr} || undef,
     Proto      => 'tcp',
     ($class eq 'IO::Socket::IP' ? 'Family' : 'Domain')     => $domain,
+    # Work around IO::Socket::IP defaulting to AI_ADDRCONFIG which breaks
+    # resolution if only a loopback interface is available. CPAN RT#104793.
+    ($class eq 'IO::Socket::IP' and $domain ne AF_UNSPEC ? ('GetAddrInfoFlags' => 0) : ()),
     MultiHomed => $arg->{multihomed},
     Timeout    => defined $arg->{timeout}
 		 ? $arg->{timeout}


### PR DESCRIPTION
t/40connect.t fails if the only available network interface is
loopback and IO::Socket::IP is installed:

    # perl -Ilib -I. t/40connect.t
    1..3
    ok 1 - client with IPv4/IPv6 auto-selection, bound to ::1
    ldap://localhost:9009/ Name or service not known at t/common.pl line 157.
    # Looks like your test exited with 22 just after 1.

The reason is that IO::Socket::IP by default resolves host names with
AI_ADDRCONFIG flag and in the particular case (no interfaces other
than loopback) a system resolver (glibc in my case) hides both IPv4
and IPv6 addreses of the hostname (e.g. localhost).

See <https://rt.cpan.org/Ticket/Display.html?id=104793> for more
details.

I applied a workaround similar to one found in IO-Socket-SSL.
I believe that other Socket implementations perl-ldap can use do not
suffer from this problem.