### PR TITLE
Add utility functions for converting Microsoft FILETIMEs to UNIX timestamps

### DIFF
--- a/lib/Net/LDAP/Util.pm
+++ b/lib/Net/LDAP/Util.pm
@@ -897,7 +897,7 @@ not validate whether its return value is a true 32-bit UNIX timestamp or not.
 
 =cut
 
-sub filetime_to_time($) {
+sub filetime_to_time {
 	use bigint;
 	my $filetime = shift;
 	return undef unless( $filetime );
@@ -927,7 +927,7 @@ precise to the second.
 
 =cut
 
-sub time_to_filetime($) {
+sub time_to_filetime {
 	use bigint;
 	my $time = shift;
 	return undef unless $time;

--- a/lib/Net/LDAP/Util.pm
+++ b/lib/Net/LDAP/Util.pm
@@ -47,8 +47,8 @@ our @EXPORT_OK = qw(
   ldap_url_parse
   generalizedTime_to_time
   time_to_generalizedTime
-	filetime_to_time
-	time_to_filetime
+  filetime_to_time
+  time_to_filetime
 );
 our %EXPORT_TAGS = (
 	error	=> [ qw(ldap_error_name ldap_error_text ldap_error_desc) ],
@@ -59,7 +59,7 @@ our %EXPORT_TAGS = (
 	                escape_dn_value unescape_dn_value) ],
 	url   	=> [ qw(ldap_url_parse) ],
 	time	=> [ qw(generalizedTime_to_time time_to_generalizedTime
-								filetime_to_time time_to_filetime) ],
+			filetime_to_time time_to_filetime) ],
 );
 
 our $VERSION = '0.21';


### PR DESCRIPTION
I've recently been doing a fair amount of work with Active Directory using Net::LDAP, and have found myself needing to convert Microsoft's FILETIME timestamp formats to something more useful in many of my scripts. Microsoft uses this format for a number of attributes, including lastLogon/lastLogonTimeStamp, pwdLastSet, accountExpires, and more. 

I figured these made sense to also have alongside the functions for converting between generalizedTimes (which I'm pretty sure AD *also* uses, for some things...) and UNIX timestamps for anyone else that uses this module to interface with AD.

I've kept the functions pretty simple for now to offer more flexibility, but if you think it would be better for me to be more strict with the input/output validation (or offer more functionality?), I'm willing to add that.